### PR TITLE
Shrink representation section images by half on about page

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -67,7 +67,7 @@ const Representation = ({
                 width={rep.image.dimensions?.width}
                 height={rep.image.dimensions?.height}
                 alt={rep.title || 'Representation'}
-                className="mb-4 mx-auto w-60"
+                className="mb-4 mx-auto w-30"
                 quality={100}
               />
             )}


### PR DESCRIPTION
Change image width from w-60 (240px) to w-30 (120px) in the
representation section.

https://claude.ai/code/session_019aENjzwHZwF4EpXCJSVbax